### PR TITLE
Introduce cascading deletes for batches and certificates

### DIFF
--- a/app/components/ui/checkbox.tsx
+++ b/app/components/ui/checkbox.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable react/prop-types */
+import {
+  forwardRef,
+  type ElementRef,
+  type ComponentPropsWithoutRef,
+} from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+const Checkbox = forwardRef<
+  ElementRef<typeof CheckboxPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/app/routes/org.program.$programId.batch.$batchId.delete.tsx
+++ b/app/routes/org.program.$programId.batch.$batchId.delete.tsx
@@ -1,12 +1,14 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.delete";
 
 import type { ErrorResponse } from "react-router";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   redirect,
   useNavigate,
   useRouteError,
   isRouteErrorResponse,
+  Form,
+  Link,
 } from "react-router";
 import { requireAdminWithProgram } from "~/lib/auth.server";
 import { prisma, throwErrorResponse } from "~/lib/prisma.server";
@@ -20,27 +22,128 @@ import {
   DialogFooter,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { Label } from "~/components/ui/label";
+import { Trash2Icon } from "lucide-react";
+import { Checkbox } from "~/components/ui/checkbox";
 
 export async function action({ request, params }: Route.ActionArgs) {
   await requireAdminWithProgram(request, Number(params.programId));
 
-  await prisma.batch
-    .delete({
-      where: {
-        id: Number(params.batchId),
-        programId: Number(params.programId),
-      },
-    })
-    .catch((error) => {
-      console.error(error);
-      throwErrorResponse(error, "Could not delete batch");
-    });
+  const formData = await request.formData();
+  if (formData.has("confirm") && formData.get("confirm") === "Y") {
+    await prisma.batch
+      .delete({
+        where: {
+          id: Number(params.batchId),
+          programId: Number(params.programId),
+        },
+      })
+      .catch((error) => {
+        console.error(error);
+        throwErrorResponse(error, "Could not delete batch");
+      });
+  } else {
+    throwErrorResponse(
+      new Error("Missing confirmation"),
+      "Please check the box if you really want to delete the batch",
+    );
+  }
 
   return redirect(`/org/program/${params.programId}/batch`);
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
-  return redirect(`/org/program/${params.programId}/batch/${params.batchId}`);
+export async function loader({ request, params }: Route.LoaderArgs) {
+  await requireAdminWithProgram(request, Number(params.programId));
+
+  const batch = await prisma.batch.findUnique({
+    where: {
+      id: Number(params.batchId),
+      programId: Number(params.programId),
+    },
+    include: {
+      _count: {
+        select: { certificates: true },
+      },
+    },
+  });
+
+  if (!batch) {
+    throw new Response(null, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return { batch };
+}
+
+export default function DeleteBatchDialog({
+  loaderData,
+  params,
+}: Route.ComponentProps) {
+  const { batch } = loaderData;
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(true);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, [navigate]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) navigate(-1);
+      }}
+    >
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Delete batch</DialogTitle>
+          <DialogDescription>
+            Please check if you want to delete the batch and all the
+            certificates in this batch.
+          </DialogDescription>
+        </DialogHeader>
+        <Form method="POST" ref={formRef} className="flex gap-2 items-center">
+          <Checkbox
+            id="confirm"
+            name="confirm"
+            value="Y"
+            defaultChecked={false}
+          />
+          <Label htmlFor="confirm">
+            Delete {batch._count.certificates} certificates and the batch.
+          </Label>
+        </Form>
+        <p className="text-sm text-muted-foreground">
+          Deleting the certificates cannot be undone. Certificates that have
+          been shared cannot be verified anymore when they are deleted.
+        </p>
+        <DialogFooter className="flex justify-between">
+          <Link
+            to={`/org/program/${params.programId}/batch/${params.batchId}/certificates`}
+          >
+            <Button variant="outline">Cancel</Button>
+          </Link>
+          <Button
+            onClick={() => formRef.current?.submit()}
+            variant="destructive"
+          >
+            <Trash2Icon /> Delete batch
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 export function ErrorBoundary() {

--- a/app/routes/org.program.$programId.batch.$batchId.edit.tsx
+++ b/app/routes/org.program.$programId.batch.$batchId.edit.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.edit";
 
 import { useEffect, useState, useRef } from "react";
-import { Form, redirect, useNavigate } from "react-router";
+import { Form, Link, redirect, useNavigate } from "react-router";
 
 import { Trash2Icon } from "lucide-react";
 import { Button } from "~/components/ui/button";
@@ -69,7 +69,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { batch };
 }
 
-export default function EditBatchDialog({ loaderData }: Route.ComponentProps) {
+export default function EditBatchDialog({
+  loaderData,
+  params,
+}: Route.ComponentProps) {
   const { batch } = loaderData;
   const navigate = useNavigate();
   const [open, setOpen] = useState(true);
@@ -120,21 +123,20 @@ export default function EditBatchDialog({ loaderData }: Route.ComponentProps) {
             defaultValue={batch.endDate.toISOString().split("T")[0]}
           />
         </Form>
-        <DialogFooter>
-          <Form
-            action={`../${batch.id}/delete`}
-            method="POST"
-            className="flex grow"
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button type="submit" variant="destructive" size="icon">
+        <DialogFooter className="flex justify-between">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                to={`/org/program/${params.programId}/batch/${params.batchId}/delete`}
+              >
+                <Button variant="destructive" size="icon">
                   <Trash2Icon />
                 </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top">Delete this batch</TooltipContent>
-            </Tooltip>
-          </Form>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="top">Delete this batch</TooltipContent>
+          </Tooltip>
+
           <Button onClick={() => formRef.current?.submit()}>
             Save changes
           </Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@pdf-lib/fontkit": "^1.1.1",
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -2282,19 +2283,49 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
-      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -10977,6 +11008,36 @@
         "@radix-ui/react-use-layout-effect": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@pdf-lib/fontkit": "^1.1.1",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/prisma/migrations/20250919095943_cascade_delete_batch_certificates/migration.sql
+++ b/prisma/migrations/20250919095943_cascade_delete_batch_certificates/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "certificates" DROP CONSTRAINT "certificates_batchId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "certificates" ADD CONSTRAINT "certificates_batchId_fkey" FOREIGN KEY ("batchId") REFERENCES "batches"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,7 +140,7 @@ model Certificate {
   firstName     String  
   lastName      String
   email         String
-  batch         Batch @relation(fields: [batchId], references: [id])
+  batch         Batch @relation(fields: [batchId], references: [id], onDelete: Cascade)
   batchId       Int
   teamName      String?
 //team          Team? @relation(fields: [teamId], references: [id])


### PR DESCRIPTION
When a batch is deleted, also delete all the certificates inside the batch (instead of failing to delete). 

This also introduces a 2-step UI flow for deleting a batch with information about the dangers, i.e. that it cannot be undone and certificates that have been sent out can no longer be verified.