### PR TITLE
Add "download for print" option in admin UI

### DIFF
--- a/app/components/batch-action-dialog.tsx
+++ b/app/components/batch-action-dialog.tsx
@@ -121,7 +121,6 @@ export function BatchActionDialog({
 
   const handlePause = () => {
     isRunningRef.current = false;
-    revalidator.revalidate();
   };
 
   return (

--- a/app/components/download-dialog.tsx
+++ b/app/components/download-dialog.tsx
@@ -28,7 +28,8 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
   const [includeQR, setIncludeQR] = useState(false);
 
   const handleDownload = () => {
-    window.location.href = format === "zip" ? zipUrl : printUrl;
+    const base = format === "zip" ? zipUrl : printUrl;
+    window.location.href = includeQR ? `${base}?includeQR=true` : base;
     setOpen(false);
   };
 
@@ -67,9 +68,8 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
                 <FileText className="size-4" />
                 Single PDF for printing
               </div>
-              <p className="text-sm text-muted-foreground">
-                All certificates merged into one multi-page PDF, ready to print
-                or share as a single file.
+              <p className="text-sm text-muted-foreground text-pretty">
+                All certificates merged into one multi-page PDF, ready to be printed.
               </p>
             </div>
           </label>
@@ -83,7 +83,7 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
                 <FileArchive className="size-4" />
                 ZIP archive
               </div>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground text-pretty">
                 Each certificate as an individual PDF file, packed into a ZIP
                 archive.
               </p>
@@ -91,20 +91,26 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
           </label>
         </RadioGroup>
 
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="include-qr"
-            checked={includeQR}
-            onCheckedChange={(v) => setIncludeQR(v === true)}
-            disabled
-          />
-          <Label
-            htmlFor="include-qr"
-            className="text-muted-foreground cursor-not-allowed"
-          >
-            Include QR codes for unpublished certificates
-          </Label>
-        </div>
+        <label
+          htmlFor="include-qr"
+          className="flex flex-col gap-2 rounded-lg p-4 pt-2 cursor-pointer"
+        >
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="include-qr"
+              checked={includeQR}
+              onCheckedChange={(v) => setIncludeQR(v === true)}
+              className="cursor-pointer"
+            />
+            <Label htmlFor="include-qr" className="cursor-pointer">
+              Show QR codes for unpublished certificates
+            </Label>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            If you enable this option, make sure to publish the certificates
+            before handing over the printed version.
+          </p>
+        </label>
 
         <DialogFooter>
           <Button onClick={handleDownload}>Download now</Button>

--- a/app/components/download-dialog.tsx
+++ b/app/components/download-dialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Download, FileArchive, FileText } from "lucide-react";
+import { Download, FileArchive, FileText, Loader2 } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -26,15 +26,45 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
   const [open, setOpen] = useState(false);
   const [format, setFormat] = useState<DownloadFormat>("print");
   const [includeQR, setIncludeQR] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
+    setIsDownloading(true);
     const base = format === "zip" ? zipUrl : printUrl;
-    window.location.href = includeQR ? `${base}?includeQR=true` : base;
-    setOpen(false);
+    const url = includeQR ? `${base}?includeQR=true` : base;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error("Download failed");
+
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+
+      const disposition = response.headers.get("content-disposition");
+      const match = disposition?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+      a.download = match
+        ? match[1].replace(/['"]/g, "")
+        : format === "zip"
+          ? "certificates.zip"
+          : "certificates.pdf";
+
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(objectUrl);
+
+      setOpen(false);
+    } catch {
+      window.location.href = url;
+    } finally {
+      setIsDownloading(false);
+    }
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={(v) => !isDownloading && setOpen(v)}>
       <DialogTrigger asChild>
         <Button variant="outline">
           <Download />
@@ -53,6 +83,7 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
           value={format}
           onValueChange={(v) => setFormat(v as DownloadFormat)}
           className="flex flex-col gap-3"
+          disabled={isDownloading}
         >
           <label
             htmlFor="format-print"
@@ -101,6 +132,7 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
               checked={includeQR}
               onCheckedChange={(v) => setIncludeQR(v === true)}
               className="cursor-pointer"
+              disabled={isDownloading}
             />
             <Label htmlFor="include-qr" className="cursor-pointer">
               Show QR codes for unpublished certificates
@@ -113,7 +145,16 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
         </label>
 
         <DialogFooter>
-          <Button onClick={handleDownload}>Download now</Button>
+          <Button onClick={handleDownload} disabled={isDownloading}>
+            {isDownloading ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Preparing download…
+              </>
+            ) : (
+              "Download certificates"
+            )}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/app/components/download-dialog.tsx
+++ b/app/components/download-dialog.tsx
@@ -41,14 +41,7 @@ export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
       const objectUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = objectUrl;
-
-      const disposition = response.headers.get("content-disposition");
-      const match = disposition?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
-      a.download = match
-        ? match[1].replace(/['"]/g, "")
-        : format === "zip"
-          ? "certificates.zip"
-          : "certificates.pdf";
+      a.download = format === "zip" ? "certificates.zip" : "certificates-print.pdf";
 
       document.body.appendChild(a);
       a.click();

--- a/app/components/download-dialog.tsx
+++ b/app/components/download-dialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Download, FileArchive, FileText } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Label } from "~/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group";
+
+type DownloadFormat = "zip" | "print";
+
+type DownloadDialogProps = {
+  zipUrl: string;
+  printUrl: string;
+};
+
+export function DownloadDialog({ zipUrl, printUrl }: DownloadDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [format, setFormat] = useState<DownloadFormat>("print");
+  const [includeQR, setIncludeQR] = useState(false);
+
+  const handleDownload = () => {
+    window.location.href = format === "zip" ? zipUrl : printUrl;
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Download />
+          Download All
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Download all certificates</DialogTitle>
+          <DialogDescription>
+            Choose how you want to download the certificates for this batch.
+          </DialogDescription>
+        </DialogHeader>
+
+        <RadioGroup
+          value={format}
+          onValueChange={(v) => setFormat(v as DownloadFormat)}
+          className="flex flex-col gap-3"
+        >
+          <label
+            htmlFor="format-print"
+            className="flex items-start gap-3 rounded-lg border p-4 cursor-pointer has-[[data-state=checked]]:border-primary"
+          >
+            <RadioGroupItem
+              value="print"
+              id="format-print"
+              className="mt-0.5"
+            />
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2 font-medium text-sm">
+                <FileText className="size-4" />
+                Single PDF for printing
+              </div>
+              <p className="text-sm text-muted-foreground">
+                All certificates merged into one multi-page PDF, ready to print
+                or share as a single file.
+              </p>
+            </div>
+          </label>
+          <label
+            htmlFor="format-zip"
+            className="flex items-start gap-3 rounded-lg border p-4 cursor-pointer has-[[data-state=checked]]:border-primary"
+          >
+            <RadioGroupItem value="zip" id="format-zip" className="mt-0.5" />
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2 font-medium text-sm">
+                <FileArchive className="size-4" />
+                ZIP archive
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Each certificate as an individual PDF file, packed into a ZIP
+                archive.
+              </p>
+            </div>
+          </label>
+        </RadioGroup>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="include-qr"
+            checked={includeQR}
+            onCheckedChange={(v) => setIncludeQR(v === true)}
+            disabled
+          />
+          <Label
+            htmlFor="include-qr"
+            className="text-muted-foreground cursor-not-allowed"
+          >
+            Include QR codes for unpublished certificates
+          </Label>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleDownload}>Download now</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/ui/radio-group.tsx
+++ b/app/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { Circle } from "lucide-react"
+
+import { cn } from "~/lib/utils"
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/app/lib/pdf.server.ts
+++ b/app/lib/pdf.server.ts
@@ -608,6 +608,27 @@ export const sampleQR: PrismaJson.QRCode = {
   ec: "M",
 };
 
+export async function mergeCertificatesForPrint(certificates: Certificate[]) {
+  const mergedPdf = await PDFDocument.create();
+
+  for (const cert of certificates) {
+    const pdfPath = `${certDir}/${cert.id}.pdf`;
+    const pdfBytes = await readFile(pdfPath);
+    const certPdf = await PDFDocument.load(pdfBytes);
+    const copiedPages = await mergedPdf.copyPages(certPdf, certPdf.getPageIndices());
+    copiedPages.forEach((page) => mergedPdf.addPage(page));
+  }
+
+  const mergedBytes = Buffer.from(await mergedPdf.save());
+
+  return new Response(mergedBytes, {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="certificates-print.pdf"`,
+    },
+  });
+}
+
 export function downloadCertificates(certificates: Certificate[]) {
   // PassThrough stream for piping the archive directly to the response
   const stream = new PassThrough();

--- a/app/lib/pdf.server.ts
+++ b/app/lib/pdf.server.ts
@@ -84,6 +84,69 @@ async function assembleTypefacesFromLayout(
 
 // @todo dry up the code for generateCertificate and generateCertificateTemplate
 
+export async function renderCertificatePDF(
+  batch: Batch,
+  certificate: CertificatesWithBatch,
+  template: Template,
+  forceQR = false,
+) {
+  // Get PDF template // @todo simplify by loading from path string?
+  const templatePath = `${dir}/templates/${certificate.templateId}.pdf`;
+  const templateBuffer = await readFile(templatePath);
+  const pdf = await PDFDocument.load(templateBuffer);
+
+  // Load custom fonts
+  pdf.registerFontkit(fontkit);
+  const fontMap = await assembleTypefacesFromLayout(pdf, template.layout);
+
+  // Get a page reference to apply modifications
+  const page = pdf.getPages()[0];
+
+  const texts = template.layout;
+  texts.forEach((text: PrismaJson.TextBlock) => {
+    const lines = text.lines.map((line: PrismaJson.TextSegment) => {
+      const replacements = replaceVariables(
+        line.text,
+        template.locale,
+        certificate,
+        batch,
+      );
+      return { text: replacements, font: fontMap.get(line.font)! };
+    });
+
+    drawTextBlock(page, lines, {
+      size: text.size,
+      lineHeight: text.lineHeight,
+      x: text.x,
+      y: text.y,
+      maxWidth: text.maxWidth,
+      color: text.color ? rgb(...text.color) : rgb(0, 0, 0),
+      align: text.align,
+    });
+  });
+
+  // Add QR code only if the certificate has been published or user is forcing inclusion,
+  // and QR code is configured in template
+  if (
+    (certificate.publishedAt !== null || forceQR) &&
+    template.qrcode &&
+    template.qrcode.show === true
+  ) {
+    drawQRCode(
+      page,
+      `${domain}/view/${certificate.uuid}`,
+      template.qrcode.x,
+      template.qrcode.y,
+      template.qrcode.width,
+      template.qrcode.background,
+      template.qrcode.color,
+      template.qrcode.ec,
+    );
+  }
+
+  return Buffer.from(await pdf.save());
+}
+
 export async function generateCertificate(
   batch: Batch,
   certificate: CertificatesWithBatch,
@@ -104,69 +167,8 @@ export async function generateCertificate(
     }
   }
 
-  // Get PDF template // @todo simplify by loading from path string?
-  const templatePath = `${dir}/templates/${certificate.templateId}.pdf`;
-  const templateBuffer = await readFile(templatePath);
-  const pdf = await PDFDocument.load(templateBuffer);
-
-  // Load custom fonts
-  pdf.registerFontkit(fontkit);
-  const fontMap = await assembleTypefacesFromLayout(pdf, template.layout);
-
-  // Modify page
-  const page = pdf.getPages()[0];
-
-  const texts = template.layout;
-  texts.forEach((text: PrismaJson.TextBlock) => {
-    const lines = text.lines.map((line: PrismaJson.TextSegment) => {
-      const replacements = replaceVariables(
-        line.text,
-        template.locale,
-        certificate,
-        batch,
-      );
-
-      return {
-        text: replacements,
-        font: fontMap.get(line.font)!,
-      };
-    });
-
-    drawTextBlock(page, lines, {
-      size: text.size,
-      lineHeight: text.lineHeight,
-      x: text.x,
-      y: text.y,
-      maxWidth: text.maxWidth,
-      color: text.color ? rgb(...text.color) : rgb(0, 0, 0),
-      align: text.align,
-    });
-  });
-
-  // Add QR Code only if the certificate has been published
-  if (
-    certificate.publishedAt !== null &&
-    template.qrcode &&
-    template.qrcode.show === true
-  ) {
-    drawQRCode(
-      page,
-      `${domain}/view/${certificate.uuid}`,
-      template.qrcode.x,
-      template.qrcode.y,
-      template.qrcode.width,
-      template.qrcode.background,
-      template.qrcode.color,
-      template.qrcode.ec,
-    );
-  }
-
-  // Wrap up and return as buffer
-  const pdfBytes = await pdf.save();
-  const pdfBuffer = Buffer.from(pdfBytes);
-
+  const pdfBuffer = await renderCertificatePDF(batch, certificate, template);
   await writeFile(pdfFilePath, pdfBuffer);
-
   return pdfBuffer;
 }
 
@@ -608,12 +610,38 @@ export const sampleQR: PrismaJson.QRCode = {
   ec: "M",
 };
 
-export async function mergeCertificatesForPrint(certificates: Certificate[]) {
+export type CertEntry = { cert: Certificate; buffer?: Buffer };
+
+export async function resolveCertEntries(
+  certificates: CertificatesWithBatch[],
+  includeQR: boolean,
+): Promise<CertEntry[]> {
+  if (!includeQR) {
+    return certificates.map((cert) => ({ cert }));
+  }
+
+  const unpublished = certificates.filter((c) => c.publishedAt === null);
+  const templateIds = [...new Set(unpublished.map((c) => c.templateId))];
+  const templates = await prisma.template.findMany({ where: { id: { in: templateIds } } });
+  const templateMap = new Map(templates.map((t) => [t.id, t]));
+
+  const entries: CertEntry[] = [];
+  for (const cert of certificates) {
+    if (cert.publishedAt === null) {
+      const buffer = await renderCertificatePDF(cert.batch, cert, templateMap.get(cert.templateId)!, true);
+      entries.push({ cert, buffer });
+    } else {
+      entries.push({ cert });
+    }
+  }
+  return entries;
+}
+
+export async function mergeCertificatesForPrint(entries: CertEntry[]) {
   const mergedPdf = await PDFDocument.create();
 
-  for (const cert of certificates) {
-    const pdfPath = `${certDir}/${cert.id}.pdf`;
-    const pdfBytes = await readFile(pdfPath);
+  for (const { cert, buffer } of entries) {
+    const pdfBytes = buffer ?? (await readFile(`${certDir}/${cert.id}.pdf`));
     const certPdf = await PDFDocument.load(pdfBytes);
     const copiedPages = await mergedPdf.copyPages(certPdf, certPdf.getPageIndices());
     copiedPages.forEach((page) => mergedPdf.addPage(page));
@@ -629,12 +657,10 @@ export async function mergeCertificatesForPrint(certificates: Certificate[]) {
   });
 }
 
-export function downloadCertificates(certificates: Certificate[]) {
-  // PassThrough stream for piping the archive directly to the response
+export function downloadCertificates(entries: CertEntry[]) {
+  // PassThrough stream for piping the archive directly to the response  
   const stream = new PassThrough();
-  const archive = archiver("zip", {
-    zlib: { level: 9 }, // Sets the compression level.
-  });
+  const archive = archiver("zip", { zlib: { level: 9 } });
   const zipFilename = "certificates.zip";
 
   archive.on("error", (err: Error) => {
@@ -642,24 +668,23 @@ export function downloadCertificates(certificates: Certificate[]) {
     stream.emit("error", err);
   });
 
-  // Pipe archive data into the PassThrough stream
   archive.pipe(stream);
 
-  // Add files to the archive
-  certificates.forEach((cert) => {
-    archive.file(`${certDir}/${cert.id}.pdf`, {
-      name: cert.teamName
-        ? `${slug(cert.teamName)}/${slug(cert.firstName)} ${slug(
-            cert.lastName || "",
-          )}.certificate.pdf`
-        : `${slug(cert.firstName)} ${slug(cert.lastName || "")}.certificate.pdf`,
-    });
+  entries.forEach(({ cert, buffer }) => {
+    const name = cert.teamName
+      ? `${slug(cert.teamName)}/${slug(cert.firstName)} ${slug(cert.lastName || "")}.certificate.pdf`
+      : `${slug(cert.firstName)} ${slug(cert.lastName || "")}.certificate.pdf`;
+
+    if (buffer) {
+      archive.append(buffer, { name });
+    } else {
+      archive.file(`${certDir}/${cert.id}.pdf`, { name });
+    }
   });
 
   // Finalize the archive (starts streaming to the response)
   archive.finalize();
 
-  // Return the streaming response
   return new Response(stream as unknown as BodyInit, {
     headers: {
       "Content-Type": "application/zip",

--- a/app/lib/pdf.server.ts
+++ b/app/lib/pdf.server.ts
@@ -610,25 +610,32 @@ export const sampleQR: PrismaJson.QRCode = {
   ec: "M",
 };
 
-export type CertEntry = { cert: Certificate; buffer?: Buffer };
+export type CertificateData = { cert: Certificate; buffer?: Buffer };
 
-export async function resolveCertEntries(
+export async function resolveCertificateData(
   certificates: CertificatesWithBatch[],
   includeQR: boolean,
-): Promise<CertEntry[]> {
+): Promise<CertificateData[]> {
   if (!includeQR) {
     return certificates.map((cert) => ({ cert }));
   }
 
   const unpublished = certificates.filter((c) => c.publishedAt === null);
   const templateIds = [...new Set(unpublished.map((c) => c.templateId))];
-  const templates = await prisma.template.findMany({ where: { id: { in: templateIds } } });
+  const templates = await prisma.template.findMany({
+    where: { id: { in: templateIds } },
+  });
   const templateMap = new Map(templates.map((t) => [t.id, t]));
 
-  const entries: CertEntry[] = [];
+  const entries: CertificateData[] = [];
   for (const cert of certificates) {
     if (cert.publishedAt === null) {
-      const buffer = await renderCertificatePDF(cert.batch, cert, templateMap.get(cert.templateId)!, true);
+      const buffer = await renderCertificatePDF(
+        cert.batch,
+        cert,
+        templateMap.get(cert.templateId)!,
+        true,
+      );
       entries.push({ cert, buffer });
     } else {
       entries.push({ cert });
@@ -637,13 +644,16 @@ export async function resolveCertEntries(
   return entries;
 }
 
-export async function mergeCertificatesForPrint(entries: CertEntry[]) {
+export async function mergeCertificatesForPrint(entries: CertificateData[]) {
   const mergedPdf = await PDFDocument.create();
 
   for (const { cert, buffer } of entries) {
     const pdfBytes = buffer ?? (await readFile(`${certDir}/${cert.id}.pdf`));
     const certPdf = await PDFDocument.load(pdfBytes);
-    const copiedPages = await mergedPdf.copyPages(certPdf, certPdf.getPageIndices());
+    const copiedPages = await mergedPdf.copyPages(
+      certPdf,
+      certPdf.getPageIndices(),
+    );
     copiedPages.forEach((page) => mergedPdf.addPage(page));
   }
 
@@ -657,8 +667,8 @@ export async function mergeCertificatesForPrint(entries: CertEntry[]) {
   });
 }
 
-export function downloadCertificates(entries: CertEntry[]) {
-  // PassThrough stream for piping the archive directly to the response  
+export function downloadCertificates(entries: CertificateData[]) {
+  // PassThrough stream for piping the archive directly to the response
   const stream = new PassThrough();
   const archive = archiver("zip", { zlib: { level: 9 } });
   const zipFilename = "certificates.zip";

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
@@ -1,23 +1,21 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.certificates.download-print[.pdf]";
 
 import { requireAdminWithProgram } from "~/lib/auth.server";
-import { mergeCertificatesForPrint } from "~/lib/pdf.server";
+import { mergeCertificatesForPrint, resolveCertEntries } from "~/lib/pdf.server";
 import { prisma } from "~/lib/prisma.server";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   await requireAdminWithProgram(request, Number(params.programId));
 
+  const includeQR = new URL(request.url).searchParams.get("includeQR") === "true";
+
   const certificates = await prisma.certificate.findMany({
     where: {
-      batch: {
-        is: {
-          id: Number(params.batchId),
-          programId: Number(params.programId),
-        },
-      },
+      batch: { is: { id: Number(params.batchId), programId: Number(params.programId) } },
     },
+    include: { batch: true },
     orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
   });
 
-  return mergeCertificatesForPrint(certificates);
+  return mergeCertificatesForPrint(await resolveCertEntries(certificates, includeQR));
 }

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
@@ -1,21 +1,29 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.certificates.download-print[.pdf]";
 
 import { requireAdminWithProgram } from "~/lib/auth.server";
-import { mergeCertificatesForPrint, resolveCertEntries } from "~/lib/pdf.server";
+import {
+  mergeCertificatesForPrint,
+  resolveCertificateData,
+} from "~/lib/pdf.server";
 import { prisma } from "~/lib/prisma.server";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   await requireAdminWithProgram(request, Number(params.programId));
 
-  const includeQR = new URL(request.url).searchParams.get("includeQR") === "true";
+  const includeQR =
+    new URL(request.url).searchParams.get("includeQR") === "true";
 
   const certificates = await prisma.certificate.findMany({
     where: {
-      batch: { is: { id: Number(params.batchId), programId: Number(params.programId) } },
+      batch: {
+        is: { id: Number(params.batchId), programId: Number(params.programId) },
+      },
     },
     include: { batch: true },
     orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
   });
 
-  return mergeCertificatesForPrint(await resolveCertEntries(certificates, includeQR));
+  return mergeCertificatesForPrint(
+    await resolveCertificateData(certificates, includeQR),
+  );
 }

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.download-print[.pdf].ts
@@ -1,0 +1,23 @@
+import type { Route } from "./+types/org.program.$programId.batch.$batchId.certificates.download-print[.pdf]";
+
+import { requireAdminWithProgram } from "~/lib/auth.server";
+import { mergeCertificatesForPrint } from "~/lib/pdf.server";
+import { prisma } from "~/lib/prisma.server";
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  await requireAdminWithProgram(request, Number(params.programId));
+
+  const certificates = await prisma.certificate.findMany({
+    where: {
+      batch: {
+        is: {
+          id: Number(params.batchId),
+          programId: Number(params.programId),
+        },
+      },
+    },
+    orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+  });
+
+  return mergeCertificatesForPrint(certificates);
+}

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.download[.zip].ts
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.download[.zip].ts
@@ -1,23 +1,21 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.certificates.download[.zip]";
 
 import { requireAdminWithProgram } from "~/lib/auth.server";
-import { downloadCertificates } from "~/lib/pdf.server";
+import { downloadCertificates, resolveCertEntries } from "~/lib/pdf.server";
 import { prisma } from "~/lib/prisma.server";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   await requireAdminWithProgram(request, Number(params.programId));
 
+  const includeQR = new URL(request.url).searchParams.get("includeQR") === "true";
+
   const certificates = await prisma.certificate.findMany({
     where: {
-      batch: {
-        is: {
-          id: Number(params.batchId),
-          programId: Number(params.programId),
-        },
-      },
+      batch: { is: { id: Number(params.batchId), programId: Number(params.programId) } },
     },
+    include: { batch: true },
     orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
   });
 
-  return downloadCertificates(certificates);
+  return downloadCertificates(await resolveCertEntries(certificates, includeQR));
 }

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.download[.zip].ts
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.download[.zip].ts
@@ -1,21 +1,26 @@
 import type { Route } from "./+types/org.program.$programId.batch.$batchId.certificates.download[.zip]";
 
 import { requireAdminWithProgram } from "~/lib/auth.server";
-import { downloadCertificates, resolveCertEntries } from "~/lib/pdf.server";
+import { downloadCertificates, resolveCertificateData } from "~/lib/pdf.server";
 import { prisma } from "~/lib/prisma.server";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   await requireAdminWithProgram(request, Number(params.programId));
 
-  const includeQR = new URL(request.url).searchParams.get("includeQR") === "true";
+  const includeQR =
+    new URL(request.url).searchParams.get("includeQR") === "true";
 
   const certificates = await prisma.certificate.findMany({
     where: {
-      batch: { is: { id: Number(params.batchId), programId: Number(params.programId) } },
+      batch: {
+        is: { id: Number(params.batchId), programId: Number(params.programId) },
+      },
     },
     include: { batch: true },
     orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
   });
 
-  return downloadCertificates(await resolveCertEntries(certificates, includeQR));
+  return downloadCertificates(
+    await resolveCertificateData(certificates, includeQR),
+  );
 }

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
@@ -12,6 +12,7 @@ import {
   LayoutGrid,
   MailCheck,
   MailOpen,
+  RefreshCw,
   Send,
   TableIcon,
 } from "lucide-react";
@@ -94,13 +95,13 @@ export default function BatchCertificatesPage({
     templatesMap.set(template.id, template);
   }
 
-  let certificatesNeedsRefresh = 0;
+  const certificatesNeedingRefresh = new Set<number>();
   for (const certificate of certificates) {
     const lastTemplateUpdate = templatesMap.get(
       certificate.templateId,
     )?.updatedAt;
     if (lastTemplateUpdate && lastTemplateUpdate > certificate.updatedAt) {
-      certificatesNeedsRefresh++;
+      certificatesNeedingRefresh.add(certificate.id);
     }
   }
 
@@ -172,6 +173,25 @@ export default function BatchCertificatesPage({
         </Button>
 
         <div className="flex-grow">&emsp;</div>
+
+        {certificatesNeedingRefresh.size > 0 && (
+          <BatchActionDialog
+            certificates={certificates}
+            triggerIcon={<RefreshCw />}
+            triggerLabel="Refresh All"
+            primary={true}
+            title="Refresh all certificates"
+            description="Some certificates are based on a template that has been updated since they were last generated. Refreshing will regenerate them with the latest version of the template."
+            actionLabel="Refresh certificates"
+            progressLabel="are up to date"
+            allDoneMessage="all certificates up to date"
+            toastTitle="All certificates refreshed!"
+            filterFn={(c) => certificatesNeedingRefresh.has(c.id)}
+            getEndpoint={(c) =>
+              `/org/program/${params.programId}/batch/${params.batchId}/certificates/${c.id}/refresh`
+            }
+          />
+        )}
 
         <DownloadDialog
           zipUrl={`/org/program/${params.programId}/batch/${params.batchId}/certificates/download.zip`}
@@ -272,15 +292,15 @@ export default function BatchCertificatesPage({
                     </Link>
                   </Button>
                   &emsp;
-                  {certificatesNeedsRefresh > 0 && (
+                  {certificatesNeedingRefresh.size > 0 && (
                     <Tooltip>
                       <TooltipTrigger>
                         <Badge variant="destructive">
-                          {certificatesNeedsRefresh}
+                          {certificatesNeedingRefresh.size}
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent side="top">
-                        {certificatesNeedsRefresh} certificates need to be
+                        {certificatesNeedingRefresh.size} certificates need to be
                         refreshed
                       </TooltipContent>
                     </Tooltip>

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
@@ -7,7 +7,6 @@ import {
   BadgeCheck,
   BadgeIcon,
   BadgePlus,
-  Download,
   Eye,
   FileUp,
   LayoutGrid,
@@ -18,6 +17,7 @@ import {
 } from "lucide-react";
 
 import { BatchActionDialog } from "~/components/batch-action-dialog";
+import { DownloadDialog } from "~/components/download-dialog";
 import { CertificateRefresh } from "~/components/certificate-refresh";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -173,12 +173,10 @@ export default function BatchCertificatesPage({
 
         <div className="flex-grow">&emsp;</div>
 
-        <Button variant="outline" asChild>
-          <Link to="download.zip" reloadDocument>
-            <Download />
-            Download All
-          </Link>
-        </Button>
+        <DownloadDialog
+          zipUrl={`/org/program/${params.programId}/batch/${params.batchId}/certificates/download.zip`}
+          printUrl={`/org/program/${params.programId}/batch/${params.batchId}/certificates/download-print.pdf`}
+        />
 
         {/* @todo add check if social preview exists before publish all – show a warning if not / or general complete setup flow? */}
 

--- a/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
+++ b/app/routes/org.program.$programId.batch.$batchId.certificates.tsx
@@ -187,7 +187,7 @@ export default function BatchCertificatesPage({
           primary={!hasPublishedCertificates}
           title="Publish all certificates"
           description="A published certificate will be accessible online through it's unique link and also visible to logged-in users. Published certificates can also be verified through the included QR code. The certificates are not being emailed to recipients during this step."
-          actionLabel="Publish Now"
+          actionLabel="Publish certificates"
           progressLabel="published"
           allDoneMessage="all certificates published"
           toastTitle="All certificates published!"
@@ -203,7 +203,7 @@ export default function BatchCertificatesPage({
           primary={hasPublishedCertificates && !hasNotifiedCertificates}
           title="Send all certificates"
           description="Each participant will receive an email with their certificate attached as a PDF. Unpublished certificates will also be sent, but without a link to the online certificate."
-          actionLabel="Send Now"
+          actionLabel="Send certificates"
           progressLabel="sent"
           allDoneMessage="all certificates sent via email"
           toastTitle="All certificates sent!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.10",
+        "@radix-ui/react-radio-group": "^1.4.1",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
@@ -3755,21 +3756,20 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
-      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.1.tgz",
+      "integrity": "sha512-/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3782,6 +3782,280 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -12784,6 +13058,37 @@
       "dependencies": {
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.10",
+    "@radix-ui/react-radio-group": "^1.4.1",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",


### PR DESCRIPTION
New "Download all" option to get either a merged multi-page PDF with all certificates, or a ZIP with all individual PDF certificates.

- [x] Choose between download all certificates in a single PDF or individual certificates in a ZIP
- [x] Option to force include the QR code also for unpublished certificates (allow a prepare & print workflow without potentially revealing certificates too early)
- [x] Better info or UI feedback for downloads that take longer to prepare
- [x] Add "Refresh all" for updating certificates after template changes