### PR TITLE
Add a minimal robots.txt to avoid 404 / html error pages

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,10 @@ import { getPublicOrg } from "./lib/organisation.server";
 import styles from "./tailwind.css?url";
 import { TooltipProvider } from "./components/ui/tooltip";
 
-export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
+export const links: LinksFunction = () => [
+  { rel: "preload", href: styles, as: "style" },
+  { rel: "stylesheet", href: styles },
+];
 
 export function meta({ data }: Route.MetaArgs) {
   return [

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+
+Disallow: /org/
+Disallow: /user/
+
+Allow: /view/
+Allow: /$

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,4 +4,5 @@ Disallow: /org/
 Disallow: /user/
 
 Allow: /view/
+Allow: /user/sign/in
 Allow: /$


### PR DESCRIPTION
I ran a Chrome Lighthouse assessment and found some issues that could be improved:

- robots.txt
- LCP blocking requests (tailwind.css)